### PR TITLE
Config hash order fix

### DIFF
--- a/templates/config/types/config_block.erb
+++ b/templates/config/types/config_block.erb
@@ -1,7 +1,7 @@
 <<%= @config_name %>
-<% @config.each do |option,value| -%>
-  <%- if value.to_s != 'undef' -%>
-      <%= option %>="<%= value %>"
+<% @config.keys.sort.each do |key| -%>
+  <%- if config[key].to_s != 'undef' -%>
+      <%= key %>="<%= config[key] %>"
   <%- end -%>
 <% end -%>
  >

--- a/templates/config/types/config_block_short.erb
+++ b/templates/config/types/config_block_short.erb
@@ -1,1 +1,1 @@
-<<%= @config_name %><% @config.each do |option,value| -%><%- if value.to_s != 'undef' -%> <%= option %>="<%= value %>"<%- end -%><% end -%>>
+<<%= @config_name %><% @config.keys.sort.each do |key| -%><%- if config[key].to_s != 'undef' -%> <%= key %>="<%= config[key] %>"<%- end -%><% end -%>>


### PR DESCRIPTION
Sorts the config keys so the order is preserved across runs.
As per this issue - https://projects.puppetlabs.com/issues/16266
