### PR TITLE
Patches needed for running on Debian stretch / Ubuntu xenial with puppet >= 4

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -315,7 +315,7 @@ class inspircd::config (
       cafile     => $cafile,
       hash       => $ssl_hash,
       generate   => $generate,
-      module     => $module,
+      module     => $ssl_module,
       extra_conf => $extra_conf,
       add_bind   => $add_bind,
       bind_port  => $bind_ssl_port,

--- a/manifests/config/admin.pp
+++ b/manifests/config/admin.pp
@@ -14,7 +14,7 @@ class inspircd::config::admin (
   ::inspircd::internal::configblock { 'inspircd admin ':
     config_name => 'admin',
     config      => $config,
-    order       => '06'
+    order       => 6
   }
 
 

--- a/manifests/config/badhost.pp
+++ b/manifests/config/badhost.pp
@@ -6,7 +6,7 @@ define inspircd::config::badhost (
       type    => 'host',
       content => $name,
       reason  => $reason,
-      order   => '26',
+      order   => 26,
   }
 
 }

--- a/manifests/config/badip.pp
+++ b/manifests/config/badip.pp
@@ -7,7 +7,7 @@ define inspircd::config::badip (
       keyname => 'ipmask',
       content => $name,
       reason  => $reason,
-      order   => '24',
+      order   => 24,
   }
 
 }

--- a/manifests/config/badnick.pp
+++ b/manifests/config/badnick.pp
@@ -6,7 +6,7 @@ define inspircd::config::badnick (
       type    => 'nick',
       content => $name,
       reason  => $reason,
-      order   => '25',
+      order   => 25,
   }
 
 }

--- a/manifests/config/banlist.pp
+++ b/manifests/config/banlist.pp
@@ -11,7 +11,7 @@ define inspircd::config::banlist (
   ::inspircd::internal::configblock { "inspircd banlist ${chan}":
     config_name => 'banlist',
     config      => $config,
-    order       => '16'
+    order       => 16
   }
 
 }

--- a/manifests/config/bind.pp
+++ b/manifests/config/bind.pp
@@ -15,6 +15,6 @@ define inspircd::config::bind (
   ::inspircd::internal::configblock { "inspircd bind ${name}":
     config_name => 'bind',
     config      => $config,
-    order       => '07'
+    order       => 7
   }
 }

--- a/manifests/config/channels.pp
+++ b/manifests/config/channels.pp
@@ -11,7 +11,7 @@ class inspircd::config::channels (
   ::inspircd::internal::configblock { "inspircd ${name} ":
     config_name => 'channels',
     config      => $config,
-    order       => '12'
+    order       => 12
   }
 
 }

--- a/manifests/config/channels.pp
+++ b/manifests/config/channels.pp
@@ -5,7 +5,7 @@ class inspircd::config::channels (
 
   $config = {
     users => $users,
-    oper => $oper,
+    opers => $opers,
   }
 
   ::inspircd::internal::configblock { "inspircd ${name} ":

--- a/manifests/config/cidr.pp
+++ b/manifests/config/cidr.pp
@@ -11,7 +11,7 @@ class inspircd::config::cidr (
   ::inspircd::internal::configblock { "inspircd ${name} ":
     config_name => 'cidr',
     config      => $config,
-    order       => '10'
+    order       => 10
   }
 
 }

--- a/manifests/config/connect.pp
+++ b/manifests/config/connect.pp
@@ -1,5 +1,5 @@
 define inspircd::config::connect (
-  $order = '20',
+  $order = 20,
   $allow = '*',
   $port = undef,
   $maxchans = undef,

--- a/manifests/config/disabled.pp
+++ b/manifests/config/disabled.pp
@@ -15,7 +15,7 @@ class inspircd::config::disabled (
   ::inspircd::internal::configblock { "inspircd ${name} ":
     config_name => 'disabled',
     config      => $config,
-    order       => '17'
+    order       => 17
   }
 
 

--- a/manifests/config/dns.pp
+++ b/manifests/config/dns.pp
@@ -11,7 +11,7 @@ define inspircd::config::dns (
   ::inspircd::internal::configblock { "inspircd dns ${name} ":
     config_name => 'dns',
     config      => $config,
-    order       => '14'
+    order       => 14
   }
 
 }

--- a/manifests/config/exception.pp
+++ b/manifests/config/exception.pp
@@ -10,7 +10,7 @@ define inspircd::config::exception (
   ::inspircd::internal::configblock { "inspircd exception ${name}":
     config_name => 'exception',
     config      => $config,
-    order       => '28'
+    order       => 28
   }
 
 }

--- a/manifests/config/files.pp
+++ b/manifests/config/files.pp
@@ -20,7 +20,7 @@ class inspircd::config::files (
   concat::fragment { "inspircd config ${name}":
     target  => "${config_dir}/inspircd.conf",
     content => "<files motd=\"${config_dir}/motd.txt\" rules=\"${config_dir}/rules.txt\">\n",
-    order   => '11'
+    order   => 11
   }
 
 }

--- a/manifests/config/include.pp
+++ b/manifests/config/include.pp
@@ -15,7 +15,7 @@ define inspircd::config::include (
   concat::fragment { "${config_dir}/inspircd.conf include ${name}":
     target  => "${config_dir}/inspircd.conf",
     content => $fragment_content,
-    order   => '13'
+    order   => 13
   }
 
 }

--- a/manifests/config/insane.pp
+++ b/manifests/config/insane.pp
@@ -15,7 +15,7 @@ class inspircd::config::insane (
   ::inspircd::internal::configblock { "inspircd ${name}":
     config_name => 'insane',
     config      => $config,
-    order       => '29'
+    order       => 29
   }
 
 }

--- a/manifests/config/limits.pp
+++ b/manifests/config/limits.pp
@@ -26,7 +26,7 @@ class inspircd::config::limits (
   ::inspircd::internal::configblock { "inspircd ${name}":
     config_name => 'limits',
     config      => $config,
-    order       => '21'
+    order       => 21
   }
 
 

--- a/manifests/config/link.pp
+++ b/manifests/config/link.pp
@@ -34,7 +34,7 @@ define inspircd::config::link (
     config_name => 'link',
     config      => $config,
     section     => 'links',
-    order       => '1',
+    order       => 1,
   }
 
 }

--- a/manifests/config/log.pp
+++ b/manifests/config/log.pp
@@ -15,7 +15,7 @@ class inspircd::config::log (
   ::inspircd::internal::configblock { "inspircd ${name}":
     config_name => 'log',
     config      => $config,
-    order       => '22'
+    order       => 22
   }
 
 }

--- a/manifests/config/module.pp
+++ b/manifests/config/module.pp
@@ -8,16 +8,16 @@ define inspircd::config::module (
   }
 
   if(member(['gnutls', 'openssl'], $name)) {
-    $order = '02'
+    $order = 2
   }else{
-    $order = '08'
+    $order = 8
   }
 
   ::inspircd::internal::configblock { "inspircd module include ${name}":
     config_name => 'module',
     config      => $module_include,
     section     => 'modules',
-    order       => '02'
+    order       => 2
   }
 
   # If module configuration is available use it.

--- a/manifests/config/oper.pp
+++ b/manifests/config/oper.pp
@@ -27,7 +27,7 @@ define inspircd::config::oper (
     config_name => 'oper',
     config      => $config,
     section     => 'opers',
-    order       => '10'
+    order       => 10
   }
 
 }

--- a/manifests/config/options.pp
+++ b/manifests/config/options.pp
@@ -52,7 +52,7 @@ class inspircd::config::options (
   ::inspircd::internal::configblock { "inspircd ${name} ":
     config_name => 'options',
     config      => $config,
-    order       => '18'
+    order       => 18
   }
 
 }

--- a/manifests/config/performance.pp
+++ b/manifests/config/performance.pp
@@ -19,7 +19,7 @@ class inspircd::config::performance (
   ::inspircd::internal::configblock { "inspircd ${name} ":
     config_name => 'performance',
     config      => $config,
-    order       => '19'
+    order       => 19
   }
 
 }

--- a/manifests/config/power.pp
+++ b/manifests/config/power.pp
@@ -29,6 +29,6 @@ class inspircd::config::power (
   ::inspircd::internal::configblock { "inspircd ${name} ":
     config_name => 'power',
     config      => $config,
-    order       => '08'
+    order       => 8
   }
 }

--- a/manifests/config/section.pp
+++ b/manifests/config/section.pp
@@ -16,9 +16,6 @@ define inspircd::config::section (
     notify         => Service['inspircd'],
   }
 
-  # If any of the config files get changed restart inspircd
-  File[$config_file] ~> Service['inspircd']
-
   # Add the default template to the start of the config file.
   concat::fragment { "inspircd ${name} config":
     target  => $config_file,

--- a/manifests/config/section.pp
+++ b/manifests/config/section.pp
@@ -23,7 +23,7 @@ define inspircd::config::section (
   concat::fragment { "inspircd ${name} config":
     target  => $config_file,
     content => template("inspircd/config/${name}.conf.erb"),
-    order   => '01'
+    order   => 1
   }
 
   # Add an include for this section in the main configuration.

--- a/manifests/config/security.pp
+++ b/manifests/config/security.pp
@@ -39,7 +39,7 @@ class inspircd::config::security (
   ::inspircd::internal::configblock { "inspircd ${name} ":
     config_name => 'security',
     config      => $config,
-    order       => '20'
+    order       => 20
   }
 
 }

--- a/manifests/config/server.pp
+++ b/manifests/config/server.pp
@@ -13,7 +13,7 @@ class inspircd::config::server (
   ::inspircd::internal::configblock { "inspircd ${name}":
     config_name => 'server',
     config      => $config,
-    order       => '05'
+    order       => 5
   }
 
 }

--- a/manifests/config/ssl.pp
+++ b/manifests/config/ssl.pp
@@ -3,6 +3,7 @@ class inspircd::config::ssl (
   $keyfile = $inspircd::params::ssl_keyfile,
   $dhfile = undef,
   $cafile = undef,
+  $crlfile = undef,
   $hash = $inspircd::params::ssl_hash,
   $generate = true,
   $module = $inspircd::params::ssl_module,

--- a/manifests/config/uline.pp
+++ b/manifests/config/uline.pp
@@ -12,7 +12,7 @@ define inspircd::config::uline (
     config_name => 'uline',
     config      => $config,
     section     => 'links',
-    order       => '2',
+    order       => 2,
   }
 
 }

--- a/manifests/config/whowas.pp
+++ b/manifests/config/whowas.pp
@@ -14,7 +14,7 @@ class inspircd::config::whowas (
   ::inspircd::internal::configblock { "inspircd ${name}":
     config_name => 'whowas',
     config      => $config,
-    order       => '23'
+    order       => 23
   }
 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,7 +94,7 @@ class inspircd (
 
   # CHANNELS
   $users = $inspircd::params::users,
-  $oper = $inspircd::params::oper,
+  $opers = $inspircd::params::opers,
 
 
   # CIDR

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -354,6 +354,7 @@ class inspircd (
   class { 'inspircd::service':
     prefix         => $prefix,
     service_ensure => $service_ensure,
+    user           => $user,
   }
 
 

--- a/manifests/internal/badstuff.pp
+++ b/manifests/internal/badstuff.pp
@@ -3,7 +3,7 @@ define inspircd::internal::badstuff (
   $content,
   $reason,
   $keyname = false,
-  $order = '27',
+  $order = 27,
 ) {
 
   assert_private('This type is private.')

--- a/manifests/modules/alias.pp
+++ b/manifests/modules/alias.pp
@@ -51,7 +51,7 @@ define inspircd::modules::alias (
     config_name => 'alias',
     config      => $config,
     section     => 'modules',
-    order       => '12',
+    order       => 12,
   }
 
 }

--- a/manifests/modules/badchan.pp
+++ b/manifests/modules/badchan.pp
@@ -15,7 +15,7 @@ define inspircd::modules::badchan (
     config_name => 'badchan',
     config      => $config,
     section     => 'modules',
-    order       => '2'
+    order       => 2
   }
 
 }

--- a/manifests/modules/badword.pp
+++ b/manifests/modules/badword.pp
@@ -11,7 +11,7 @@ define inspircd::modules::badword (
     config_name => 'badword',
     config      => $config,
     section     => 'modules',
-    order       => '2'
+    order       => 2
   }
 
 }

--- a/manifests/modules/banfile.pp
+++ b/manifests/modules/banfile.pp
@@ -12,7 +12,7 @@ define inspircd::modules::banfile (
     config_name => 'banfile',
     config      => $config,
     section     => 'modules',
-    order       => '2'
+    order       => 2
   }
 
 }

--- a/manifests/modules/openssl.pp
+++ b/manifests/modules/openssl.pp
@@ -4,6 +4,7 @@ class inspircd::modules::openssl (
   $dhfile = undef,
   $cafile = undef,
   $hash = 'sha1',
+  $crlfile = undef,
   $ciphers = undef,
   $customcontextoptions = undef,
   $cipherserverpref = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,12 +23,12 @@ class inspircd::params {
       ]
 
       $packages_gnutls = [
-        'libgnutls-dev',
+        'libgnutls28-dev',
         'gnutls-bin',
       ]
 
       $packages_openssl = [
-        'libssl1.0.0',
+        'libssl1.1',
         'libssl-dev',
         'openssl',
         'libcurl4-openssl-dev',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -118,7 +118,7 @@ class inspircd::params {
   $rules = ''
 
   $commands = ''
-  $femodes = ''
+  $usermodes = ''
   $chanmodes = ''
   $fakenonexistant = 'yes'
 
@@ -152,7 +152,7 @@ class inspircd::params {
   $secret = "secret ${::domain}"
 
   $users = '20'
-  $oper = '60'
+  $opers = '60'
 
   $ipv4clone = '32'
   $ipv6clone = '128'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,6 +1,7 @@
 class inspircd::service (
   $prefix = $inspircd::params::prefix,
   $service_ensure = $inspircd::params::service_ensure,
+  $user = $inspircd::params::user,
 ) inherits inspircd::params {
 
 

--- a/templates/config/types/config_block.erb
+++ b/templates/config/types/config_block.erb
@@ -1,7 +1,7 @@
 <<%= @config_name %>
 <% @config.keys.sort.each do |key| -%>
-  <%- if config[key].to_s != 'undef' -%>
-      <%= key %>="<%= config[key] %>"
+  <%- if @config[key].to_s != 'undef' -%>
+      <%= key %>="<%= @config[key] %>"
   <%- end -%>
 <% end -%>
  >

--- a/templates/config/types/config_block_short.erb
+++ b/templates/config/types/config_block_short.erb
@@ -1,1 +1,1 @@
-<<%= @config_name %><% @config.keys.sort.each do |key| -%><%- if config[key].to_s != 'undef' -%> <%= key %>="<%= config[key] %>"<%- end -%><% end -%>>
+<<%= @config_name %><% @config.keys.sort.each do |key| -%><%- if @config[key].to_s != 'undef' -%> <%= key %>="<%= @config[key] %>"<%- end -%><% end -%>>

--- a/templates/configure_wrapper.erb
+++ b/templates/configure_wrapper.erb
@@ -17,10 +17,10 @@
 <% if @kqueue -%>
   --enable-kqueue \
 <% end -%>
-  --prefix=<%= prefix %> \
-  --binary-dir=<%= binary_dir %> \
-  --module-dir=<%= module_dir %> \
-  --config-dir=<%= config_dir %> \
-  --data-dir=<%= data_dir %> \
-  --log-dir=<%= log_dir %> \
-  --uid=<%= user %>
+  --prefix=<%= @prefix %> \
+  --binary-dir=<%= @binary_dir %> \
+  --module-dir=<%= @module_dir %> \
+  --config-dir=<%= @config_dir %> \
+  --data-dir=<%= @data_dir %> \
+  --log-dir=<%= @log_dir %> \
+  --uid=<%= @user %>

--- a/templates/configure_wrapper.erb
+++ b/templates/configure_wrapper.erb
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+export PERL5LIB=<%= @install_dir %>
 ./configure \
   --disable-interactive \
 <% @compile_extra_modules.each do |value| -%>


### PR DESCRIPTION
I tried to use this module to get inspircd running on Debian stretch using a recent version of puppet, and bumped into a lot of minor issues. I'm sure there are more corner cases lurking around, but with the changes in this pull request I was able to get inspircd running with the following manifest:

```puppet
class {'inspircd':
  modules     => ['ssl_gnutls'],
  ssl_module  => 'gnutls',
  description => 'Some IRCd description',
  nick        => 'ircop',
  restartpass => 'restartme',
  diepass     => 'killme',
}

::inspircd::config::oper { 'ircop':
  password => 'asparagus',
  host => '*',
  type => 'NetAdmin',
  require => Class['inspircd'],
}
```

I tested the manifest on Debian stretch and Ubuntu xenial using Puppet 4.10.10, and succeeded in starting the ircd.

The parameters `restartpass` and `diepass` needs to be set, so I guess the example in the README should be updated as well to reflect this.